### PR TITLE
Enh/ship data

### DIFF
--- a/gtnet/run.py
+++ b/gtnet/run.py
@@ -1,6 +1,7 @@
 from .model import load_model
 from .sequence import _get_DNA_map, get_sequences, get_bidir_seq
-from .utils import get_species_pred, get_label_file, get_logger
+from .utils import get_species_pred, get_label_file
+from .utils import get_logger, get_data_path
 import numpy as np
 import pandas as pd
 import argparse
@@ -58,3 +59,10 @@ def predict(argv=None):
                     vocab=args.vocab, output_dest=args.output)
     
     logger.info('finished')
+    
+
+def run_test(argv=None):
+    data_path = get_data_path()
+    get_predictions(fasta_path=data_path, domain='archaea',
+            vocab=None, output_dest=None)
+    

--- a/gtnet/run.py
+++ b/gtnet/run.py
@@ -63,6 +63,15 @@ def predict(argv=None):
 
 def run_test(argv=None):
     data_path = get_data_path()
-    get_predictions(fasta_path=data_path, domain='archaea',
-            vocab=None, output_dest=None)
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-d', '--domain', type=str,
+                        default='archaea', help='domain',
+                        choices=['bacteria', 'archaea'])
+    parser.add_argument('-v', '--vocab', type=str,
+                        default=None, help='vocabulary')
+    parser.add_argument('-o', '--output', type=str,
+                        default=None, help='output destination')
+    args = parser.parse_args(argv)
+    get_predictions(fasta_path=data_path, domain=args.domain,
+                    vocab=args.vocab, output_dest=args.output)
     

--- a/gtnet/run_gtnet.py
+++ b/gtnet/run_gtnet.py
@@ -18,6 +18,7 @@ command_dict = {
                                'Download models if not already available'),
     'predict': Command('run.predict',
                        'Predict taxonomy of provided sequence(s)'),
+    'run-test': Command('run.run_test', 'Run gtnet on a sample dataset provided'),
 }
 
 
@@ -27,7 +28,7 @@ def print_help():
     for c, f in command_dict.items():
         nspaces = 16 - len(c)
         print(f'    {c}' + ' '*nspaces + f.doc)
-    print('    help           print this usage statememt')
+    print('    help            print this usage statememt')
     print()
 
 

--- a/gtnet/utils.py
+++ b/gtnet/utils.py
@@ -36,3 +36,13 @@ def parse_logger(string):
 
 def get_logger():
     return parse_logger('')
+
+
+
+def get_data_path():
+    """
+    Get the path to the test data 
+    Returns -- path: str (absolute path to test data file)
+    """
+    file_name = 'GCA_000006155.2.fna'
+    return os.path.join(resource_filename(__name__, 'data'), file_name)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ import subprocess
 
 from setuptools import setup, find_packages, Command
 
-
 def get_git_revision_hash():
     return subprocess.check_output(['git', 'rev-parse', 'HEAD'])
 
@@ -41,7 +40,8 @@ setup_args = {
     'install_requires': reqs,
     'packages': pkgs,
     # 'package_dir': {'': 'src'},
-    'package_data': {'gtnet': ["models/*.onnx"]},
+    'package_data': {'gtnet': ["models/*.onnx",
+                              "data/*.fna"]},
     'classifiers': [
         "Programming Language :: Python",
         "Programming Language :: Python :: 3.5",
@@ -56,7 +56,7 @@ setup_args = {
         "Operating System :: Unix",
         "Topic :: Scientific/Engineering :: Medical Science Apps."
     ],
-    #'scripts': ['bin/gtnet',],
+    #'scripts': ['bin/gtnet-predict',],
     'keywords': 'python '
                 'microbiome '
                 'microbial-taxonomy '


### PR DESCRIPTION
added default data file and relevant items (see below) for user to run inference without needing to add any additional arguments (but available if they want to modify). 

1) added data folder/data file
2) added relevant info in package_data in setup.py
3) added get_data_path function to utils.py -- similar to _get_model_path
4) added command functionality so only "run-test" needs to be called
5) added some potential arguments that can be passed to modify the default behavior
