### PR TITLE
Add script for downloading model

### DIFF
--- a/fetch_model.sh
+++ b/fetch_model.sh
@@ -1,0 +1,13 @@
+URL="https://osf.io/r6jc9/download"
+DIR=`mktemp -d`
+ZIP="$DIR/gtnet.deploy.zip"
+OUTDIR="gtnet/models"
+
+echo "Downloading model from $URL. Saving to $DIR"
+curl -L -o $ZIP $URL
+if [ ! -e $OUTDIR ]; then
+    echo "Creating $OUTDIR"
+    mkdir $OUTDIR
+fi
+echo "Extracting to $OUTDIR"
+unzip -j -d $OUTDIR $ZIP

--- a/gtnet/model.py
+++ b/gtnet/model.py
@@ -32,18 +32,3 @@ def load_model(model_path=None, domain='archaea'):
         model_path = _get_model_path(domain=domain)
     model = rt.InferenceSession(model_path)
     return model
-
-
-def download_models(argv=None):
-    required = [
-        {'path': 'gtnet/models/ar122.onnx',
-         'url': 'https://osf.io/yu738/download'}
-    ]
-    for d in required:
-        if not os.path.exists(d['path']):
-            print(f'Downloading {d["path"]} from {d["url"]}')
-            r = requests.get(d['url'], allow_redirects=True)
-            with open(d['path'], 'wb') as f:
-                f.write(r.content)
-        else:
-            print(f'{d["path"]} already exists, skipping download')

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,11 @@ def get_git_revision_short_hash():
 with open('README.md', 'r') as fp:
     readme = fp.read()
 
-pkgs = find_packages('src', exclude=['data'])
-
+reqs = ['numpy',
+        'onnxruntime',
+        'pandas',
+        'ruamel_yaml',
+        'scikit-bio']
 
 setup_args = {
     'name': 'gtnet',
@@ -27,8 +30,8 @@ setup_args = {
     'url': 'https://github.com/exabiome/gtnet',
     'license': "BSD",
     'install_requires': reqs,
-    'packages': pkgs,
-    'package_data': {'gtnet': ["models/*.onnx",
+    'packages': ['gtnet'],
+    'package_data': {'gtnet': ["models/*",
                               "data/*.fna"]},
     'classifiers': [
         "Programming Language :: Python",


### PR DESCRIPTION
This PR adds a shell script that can be used to download model data and move to the directory that `gtnet` expects to find package data.  It should be executed from within the repo directory as follows:

```bash
$ bash fetch_models.sh
```